### PR TITLE
Use appropriate status code 404 for resource not found.

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -11,7 +11,7 @@ const app = express();
 app.use("/api/v1/books", bookRoutes);
 
 app.all("*", (req, res, next) => {
-  res.status(401).json({
+  res.status(404).json({
     status: "fail",
     message: `URL NOT FOUND: ${req.protocol}://${req.get("host")}${req.url}`,
   });


### PR DESCRIPTION
Because `401` is for unauthorized URLs.